### PR TITLE
Allow users to place {{ boltforms() }} tags into content, if …

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -50,6 +50,17 @@ class Extension extends \Bolt\BaseExtension
     {
         return Extension::NAME;
     }
+    
+    /**
+     * Allow users to place {{ boltforms() }} tags into content, if
+     * `allowtwig: true` is set in the contenttype.
+     *
+     * @return boolean
+     */
+    public function isSafe()
+    {
+        return true;
+    }
 
     public function initialize()
     {


### PR DESCRIPTION
… `allowtwig: true` is set in the contenttype.