### PR TITLE
Correct match of 'submit' field

### DIFF
--- a/assets/boltforms_form.twig
+++ b/assets/boltforms_form.twig
@@ -31,7 +31,7 @@
         {{ form_errors(form) }}
 
         {% for key, value in fields  %}
-            {% if value.type != 'submit' %}
+            {% if value.config.name != 'submit' %}
                 {{ form_row(form[key]) }}
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
Because _value.type_ is always null in that iteration. 