### PR TITLE
Fixed debug usage in Email.php

### DIFF
--- a/src/Email.php
+++ b/src/Email.php
@@ -248,9 +248,7 @@ class Email
                 $debug_address = $this->config['debug']['address'];
             }
         } else {
-            if (isset($notify_form['debug']) && $notify_form['debug']) {
-                $debug = true;
-            }
+            $debug = isset($notify_form['debug']) && $notify_form['debug'];
 
             if (isset($notify_form['debug_address'])) {
                 $debug_address = $notify_form['debug_address'];


### PR DESCRIPTION
Now setting debug:false works fine

My settings are:
```yaml
application:
  notification:
    enabled: true
    debug: false
    subject: Neuer Lead
    to_name: Banovo
    to_email: sufijen.bani@banovo.de
    from_name: lastname
    from_email: email
    attach_files: false
  feedback:
    success: Vielen Dank für Ihre Anfrage!
    error: Bitte beheben Sie die Fehler im Formular
  database:
    contenttype: applications
  fields:
```

But the debug flag was set to true although I wanted `false`