### PR TITLE
Add trans to reCaptcha label

### DIFF
--- a/assets/boltforms_form.twig
+++ b/assets/boltforms_form.twig
@@ -52,7 +52,7 @@
             {% endif %}
 
             <div class="boltform-row">
-                <label for="form_message" class="required">{{ recaptcha.label }}</label>
+                <label for="form_message" class="required">{{ recaptcha.label|trans({}, translation_domain) }}</label>
                 <script src="https://www.google.com/recaptcha/api.js?hl={{ htmllang() }}" async defer></script>
                 <div class="g-recaptcha" data-sitekey="{{ recaptcha.public_key }}"></div>
             </div>


### PR DESCRIPTION
As a french developper I needed to add the translation to the reCaptcha label because of the site I am creating.

I used the same syntax as in the twig function "form_label".
We just need to add the right translation in the bolt file messages.{domain}.yml.

Hope it will help some others :).