### PR TITLE
Bolt assets directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		}
 	},
 	"extra" : {
-		"bolt-assets" : "css/boltforms.css",
+		"bolt-assets" : "css/boltforms",
 		"branch-alias" : {
 			"dev-master" : "2.3.*-dev"
 		}


### PR DESCRIPTION
The `bolt-assets` value must be a directory. If it's a file, the extension installer fails with the error:

```
RecursiveDirectoryIterator::__construct(/var/www/extensions/vendor/bolt/boltforms/css/boltforms.css): failed to open dir: Not a directory
```