### PR TITLE
Hotfix Symfony Form Events Fix

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -153,7 +153,8 @@ BoltForms exposes a number of listeners, that proxy Symfony Forms listeners:
   - `BoltFormsEvents::PRE_SET_DATA`
   - `BoltFormsEvents::POST_SET_DATA`
 
-Each of these match Symfony's constants, just with the BoltForms class name/prefix.
+Each of these match Symfony's constants, just with the BoltForms class name/prefix. 
+**Please note that the class `BoltFormsEvents` wraps around the Symfony `FormEvents`.**
 
 There are also events that trigger during the data processing:
 
@@ -182,9 +183,9 @@ class Extension extends SimpleExtension
         $dispatcher->addListener(BoltFormsEvents::PRE_SUBMIT,  array($this, 'myPostSubmit'));
     }
 
-    public function myPostSubmit($event)
+    public function myPostSubmit(BoltFormsEvents $event)
     {
-        if ($event->getForm()->getName() === 'my_form') {
+        if ($event->getEvent()->getForm()->getName() === 'my_form') {
             // Get the data from the event
             $data = $event->getData();
 

--- a/src/BoltForms.php
+++ b/src/BoltForms.php
@@ -329,7 +329,7 @@ class BoltForms
     {
         return $this->app['form.factory']
             ->createNamedBuilder($formName, $type, $data, $options)
-            ->addEventSubscriber(new SymfonyFormProxySubscriber())
+            ->addEventSubscriber(new SymfonyFormProxySubscriber($this->app))
             ->addModelTransformer(new EntityTransformer())
         ;
     }

--- a/src/Subscriber/SymfonyFormProxySubscriber.php
+++ b/src/Subscriber/SymfonyFormProxySubscriber.php
@@ -8,6 +8,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Silex\Application;
 
 /**
  * Dedicated subscriber interface for BoltForms
@@ -34,6 +35,19 @@ use Symfony\Component\Form\FormEvents;
  */
 class SymfonyFormProxySubscriber implements EventSubscriberInterface
 {
+    /** @var Application $app */
+    protected $app;
+
+    /**
+     * SymfonyFormProxySubscriber constructor.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
     /**
      * Events that BoltFormsSubscriber subscribes to
      *
@@ -127,6 +141,6 @@ class SymfonyFormProxySubscriber implements EventSubscriberInterface
     protected function dispatch($eventName, FormEvent $event, $formsEventName, EventDispatcher $dispatcher)
     {
         $event = new BoltFormsEvent($event, $formsEventName);
-        $dispatcher->dispatch($eventName, $event);
+        $this->app['dispatcher']->dispatch($eventName, $event);
     }
 }


### PR DESCRIPTION
- Updated Symfony Form events to use the proper dispatcher when dispatching events
- Updated documentation on how Bolt wraps Symfony form events