### PR TITLE
fix wrong template config key to override form theme

### DIFF
--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -8,7 +8,7 @@ or
 
 --
 templates:
-   formtheme: assets/_form_theme.twig
+   form_theme: assets/_form_theme.twig
 --
 #}
 


### PR DESCRIPTION
the comment explain how we can override the form theme within our own extension but the provided instruction are wrong.
The valid key is "form_theme" not "formtheme" as mentioned in the related  doc : 

https://bolt.github.io/boltforms/templates.html#editing-the-form-templates-for-custom-displays