### PR TITLE
allow custom query string value when redirecting

### DIFF
--- a/src/Submission/Handler/Redirect.php
+++ b/src/Submission/Handler/Redirect.php
@@ -108,7 +108,7 @@ class Redirect
                 }
             } else {
                 foreach ($query as $id => $param) {
-                    $queryParams[$id] = $formData->get($param);
+                    $queryParams[$id] = $param;
                 }
             }
         } else {


### PR DESCRIPTION
fix the code to match the doc : https://bolt.github.io/boltforms/submission.html#redirect-on-success
(previously the code was looking up the query value inside form fields key)